### PR TITLE
Add optional stats file output alongside merged file

### DIFF
--- a/corsarowdcap/Makefile.am
+++ b/corsarowdcap/Makefile.am
@@ -22,7 +22,8 @@
 # along with corsaro.  If not, see <http://www.gnu.org/licenses/>.
 # 
 
-AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/libcorsaro @TCMALLOC_FLAGS@
+AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/libcorsaro \
+	-I$(top_srcdir)/common @TCMALLOC_FLAGS@
 
 bin_PROGRAMS = corsarowdcap
 EXTRA_DIST = README exampleconfig.yaml

--- a/corsarowdcap/README
+++ b/corsarowdcap/README
@@ -95,6 +95,11 @@ The configuration options accepted by corsarowdcap are as follows:
 			captured packets do not have VLAN tags (since we
 			still have to check for them). Defaults to 'no'.
 
+  writestats            If set to 'yes', some capture and operational
+                        statistics will be written to an output file using
+                        the outtemplate pattern ('.stats' will be appended
+                        to the pattern). Defaults to 'no'.
+
 Running corsarowdcap
 ====================
 

--- a/corsarowdcap/configparser.c
+++ b/corsarowdcap/configparser.c
@@ -75,6 +75,14 @@ static int parse_remaining_config(corsaro_wdcap_global_t *glob,
         yaml_document_t *doc, yaml_node_t *key, yaml_node_t *value) {
 
     if (key->type == YAML_SCALAR_NODE && value->type == YAML_SCALAR_NODE
+        && !strcmp((char *)key->data.scalar.value, "writestats")) {
+        if (parse_onoff_option(glob, (char *)value->data.scalar.value,
+                &(glob->writestats), "write stats file") < 0) {
+            return -1;
+        }
+    }
+
+    if (key->type == YAML_SCALAR_NODE && value->type == YAML_SCALAR_NODE
             && !strcmp((char *)key->data.scalar.value, "stripvlans")) {
         if (parse_onoff_option(glob, (char *)value->data.scalar.value,
                 &(glob->stripvlans), "strip vlans") < 0) {
@@ -131,7 +139,8 @@ static void log_configuration(corsaro_wdcap_global_t *glob) {
             glob->fileformat);
     corsaro_log(glob->logger, "stripping vlans has been %s",
             glob->stripvlans ? "enabled" : "disabled");
-
+    corsaro_log(glob->logger, "stats output file creation has been %s",
+            glob->writestats ? "enabled" : "disabled");
 }
 
 static int parse_corsaro_wdcap_config(corsaro_wdcap_global_t *glob,
@@ -221,6 +230,7 @@ corsaro_wdcap_global_t *corsaro_wdcap_init_global(char *filename, int logmode) {
     glob->trace = NULL;
     glob->inputuri = NULL;
     glob->stripvlans = CORSARO_DEFAULT_WDCAP_STRIP_VLANS;
+    glob->writestats = CORSARO_DEFAULT_WDCAP_WRITE_STATS;
 
     /* Need to grab the template first, in case we need it for logging.
      * This will mean we read the config file twice... :(

--- a/corsarowdcap/exampleconfig.yaml
+++ b/corsarowdcap/exampleconfig.yaml
@@ -49,3 +49,6 @@ fileformat: pcapfile
 # run but your maximum throughput will be reduced due to time spent
 # looking for VLAN headers to remove.
 stripvlans: off
+
+# Write per-thread and overall statistics to a file
+writestats: no


### PR DESCRIPTION
If enabled (using the new `writestats` option), a "stats" file will be written alongside the merged trace file at the end of each interval. The stats file includes per-thread and overall stats as reported by libtrace, as well as the amount of time that the merge operation took. This does require that the processing threads query libtrace for stats, and send a little more data back to the merge process, but this overhead should be minimal.