### PR TITLE
Increase default constant ERF framing length to 18 bytes

### DIFF
--- a/corsarotagger/configparser.c
+++ b/corsarotagger/configparser.c
@@ -485,7 +485,7 @@ corsaro_tagger_global_t *corsaro_tagger_init_global(char *filename,
     glob->totaluris = 0;
     glob->alloceduris = 0;
     glob->filterstring = NULL;
-    glob->consterfframing = 16;     /* Typical ethernet with no extensions */
+    glob->consterfframing = CORSARO_ERF_ETHERNET_FRAMING;
     glob->promisc = 0;
     glob->logmode = logmode;
     glob->logfilename = NULL;

--- a/corsarowdcap/configparser.c
+++ b/corsarowdcap/configparser.c
@@ -224,7 +224,7 @@ corsaro_wdcap_global_t *corsaro_wdcap_init_global(char *filename, int logmode) {
     glob->monitorid = NULL;
     glob->logmode = logmode;
     glob->logfilename = NULL;
-    glob->consterfframing = 16;     // ethernet with no extension headers
+    glob->consterfframing = CORSARO_ERF_ETHERNET_FRAMING;
     glob->threads = 8;
     glob->logger = NULL;
     glob->trace = NULL;

--- a/libcorsaro/libcorsaro.h.in
+++ b/libcorsaro/libcorsaro.h.in
@@ -67,6 +67,9 @@
 #  define PRINTF(formatpos, argpos)
 #endif
 
+/** The framing length of ERF ethernet packets (ERF header len + 2
+ * bytes of padding) */
+#define CORSARO_ERF_ETHERNET_FRAMING 18
 
 #define CORSARO_MAGIC (0x45444752)
 #define CORSARO_MAGIC_INTERVAL (0x494E5452)

--- a/libcorsaro/libcorsaro_trace.c
+++ b/libcorsaro/libcorsaro_trace.c
@@ -38,6 +38,7 @@
 
 #include <wandio.h>
 #include <libtrace.h>
+#include "libcorsaro.h"
 #include "libcorsaro_log.h"
 #include "libcorsaro_trace.h"
 
@@ -444,7 +445,7 @@ int corsaro_fast_write_erf_packet(corsaro_logger_t *logger,
     /* XXX if we ever start using ERF extension headers, we will also need to
      * account for those in this calculation.
      */
-    pcapcaplen = ntohs(erfptr->rlen) - 18;
+    pcapcaplen = ntohs(erfptr->rlen) - CORSARO_ERF_ETHERNET_FRAMING;
 
     /* Check if any outstanding writes have completed */
     if (writer->waiting) {


### PR DESCRIPTION
This accounts for the 2 bytes of padding before the ethernet header.