### PR TITLE
corsarotrace: recognise intervals that are shorter than normal

### DIFF
--- a/libcorsaro/libcorsaro_plugin.c
+++ b/libcorsaro/libcorsaro_plugin.c
@@ -334,7 +334,7 @@ int corsaro_push_packet_plugins(corsaro_plugin_set_t *pset,
 }
 
 void **corsaro_push_end_plugins(corsaro_plugin_set_t *pset, uint32_t intervalid,
-        uint32_t ts) {
+        uint32_t ts, uint8_t complete) {
     corsaro_interval_t end;
     int index = 0;
     corsaro_plugin_t *p = pset->active_plugins;
@@ -350,7 +350,8 @@ void **corsaro_push_end_plugins(corsaro_plugin_set_t *pset, uint32_t intervalid,
 
     plugin_data = (void **)(calloc(pset->plugincount, sizeof(void *)));
     while (p != NULL) {
-        plugin_data[index] = p->end_interval(p, pset->plugin_state[index], &end);
+        plugin_data[index] = p->end_interval(p, pset->plugin_state[index],
+                &end, complete);
         p = p->next;
         index ++;
     }

--- a/libcorsaro/libcorsaro_plugin.h
+++ b/libcorsaro/libcorsaro_plugin.h
@@ -52,7 +52,7 @@
     int plugin##_start_interval(corsaro_plugin_t *p, void *local, \
             corsaro_interval_t *int_start);                 \
     void *plugin##_end_interval(corsaro_plugin_t *p, void *local, \
-            corsaro_interval_t *int_end);                   \
+            corsaro_interval_t *int_end, uint8_t complete);      \
     int plugin##_process_packet(corsaro_plugin_t *p, void *local, \
             libtrace_packet_t *packet, corsaro_packet_tags_t *tags); \
     char *plugin##_derive_output_name(corsaro_plugin_t *p, void *local, \
@@ -136,7 +136,7 @@ struct corsaro_plugin {
     int (*start_interval)(corsaro_plugin_t *p, void *local,
             corsaro_interval_t *int_start);
     void *(*end_interval)(corsaro_plugin_t *p, void *local,
-            corsaro_interval_t *int_end);
+            corsaro_interval_t *int_end, uint8_t complete);
     int (*process_packet)(corsaro_plugin_t *p, void *local,
             libtrace_packet_t *packet, corsaro_packet_tags_t *tags);
     char *(*derive_output_name)(corsaro_plugin_t *p, void *local,
@@ -148,7 +148,6 @@ struct corsaro_plugin {
     int (*merge_interval_results)(corsaro_plugin_t *p, void *local,
             void **tomerge, corsaro_fin_interval_t *fin);
     int (*rotate_output)(corsaro_plugin_t *p, void *local);
-    
 
 
     /* High level global state variables */
@@ -188,12 +187,11 @@ corsaro_plugin_set_t *corsaro_start_merging_plugins(corsaro_logger_t *logger,
         corsaro_plugin_t *plist, int count, int maxsources);
 int corsaro_stop_plugins(corsaro_plugin_set_t *pluginset);
 void **corsaro_push_end_plugins(corsaro_plugin_set_t *pluginset, uint32_t intid,
-        uint32_t ts);
+        uint32_t ts, uint8_t complete);
 int corsaro_push_start_plugins(corsaro_plugin_set_t *pluginset, uint32_t intid,
         uint32_t ts);
 int corsaro_push_packet_plugins(corsaro_plugin_set_t *pluginset,
         libtrace_packet_t *packet, corsaro_packet_tags_t *tags);
-
 int corsaro_rotate_plugin_output(corsaro_logger_t *logger,
         corsaro_plugin_set_t *pset);
 int corsaro_merge_plugin_outputs(corsaro_logger_t *logger,
@@ -220,7 +218,8 @@ int corsaro_is_backscatter_packet(libtrace_packet_t *packet);
 
 #define CORSARO_PLUGIN_GENERATE_MERGE_PTRS(plugin)          \
   plugin##_init_merging, plugin##_halt_merging,                 \
-  plugin##_merge_interval_results, plugin##_rotate_output       
+  plugin##_merge_interval_results,                          \
+  plugin##_rotate_output
 
 #define CORSARO_PLUGIN_GENERATE_TAIL                            \
   NULL, 0, 0, NULL, NULL

--- a/libcorsaro/plugins/corsaro_dos.c
+++ b/libcorsaro/plugins/corsaro_dos.c
@@ -971,7 +971,7 @@ static struct corsaro_dos_state_t *copy_attack_state(corsaro_plugin_t *p,
 }
 
 void *corsaro_dos_end_interval(corsaro_plugin_t *p, void *local,
-        corsaro_interval_t *int_end) {
+        corsaro_interval_t *int_end, uint8_t complete) {
 
     corsaro_dos_config_t *conf;
     struct corsaro_dos_state_t *state, *deepcopy;
@@ -1776,6 +1776,7 @@ int corsaro_dos_merge_interval_results(corsaro_plugin_t *p, void *local,
 
     config = (corsaro_dos_config_t *)(p->config);
 
+    assert(tomerge[0] != NULL);
     /* Use tomerge[0] as the "combined" result */
     combined = (struct corsaro_dos_state_t *)(tomerge[0]);
 

--- a/libcorsaro/plugins/corsaro_flowtuple.c
+++ b/libcorsaro/plugins/corsaro_flowtuple.c
@@ -420,7 +420,7 @@ static void *sort_job(void *tdata) {
 }
 
 void *corsaro_flowtuple_end_interval(corsaro_plugin_t *p, void *local,
-        corsaro_interval_t *int_end) {
+        corsaro_interval_t *int_end, uint8_t complete) {
 
     corsaro_flowtuple_config_t *conf;
     struct corsaro_flowtuple_state_t *state;
@@ -922,7 +922,7 @@ int corsaro_flowtuple_merge_interval_results(corsaro_plugin_t *p, void *local,
             }
 
             interim = (corsaro_flowtuple_interim_t *)(tomerge[i]);
-
+            assert(interim);
             if (pthread_mutex_trylock(&(interim->mutex)) == 0) {
                 if (interim->usable == 0) {
                     pthread_mutex_unlock(&(interim->mutex));


### PR DESCRIPTION
A short interval can occur at either the first interval (i.e.
because the program did not start exactly on an interval
boundary) or at the end (i.e. the program was halted in the
middle of an interval).

Depending on the plugin, it may be undesirable to publish the
results for incomplete intervals as the results could be misleading
when compared against the other longer intervals.

Any intervals ended by corsarotrace are now marked with a flag
that indicates whether the interval is complete or not. Each
plugin can choose how to behave in the incomplete case -- they
can now discard their current data if it makes sense to do so.

Existing plugins have been updated to react to incomplete
intervals as follows:

 * report -- discard
 * flowtuple -- publish
 * dos -- publish
 * filteringstats - discard