### PR TITLE
Re-enable wandio threading in corsarowdcap

### DIFF
--- a/corsarowdcap/corsarowdcap.c
+++ b/corsarowdcap/corsarowdcap.c
@@ -1074,14 +1074,6 @@ int main(int argc, char *argv[]) {
     int runerr = 0;
     int restart_triggered = 0;
 
-    /* Disable threaded I/O in libwandio, in situations where wandio is
-     * used -- we only do uncompressed output so the threading is just
-     * extra overhead for us */
-    if (setenv("LIBTRACEIO", "nothreads", 1) != 0) {
-        fprintf(stderr, "corsarowdcap: unable to set libwandio environment\n");
-        return -1;
-    }
-
     corsaro_halted = 0;
     corsaro_restart = 0;
 


### PR DESCRIPTION
Now that the merge threads are responsible for compressing their output, it is better that we use wandio threading to improve compress performance.