### PR TITLE
report plugin: fix slow memory leak when doing libtimeseries output

### DIFF
--- a/libcorsaro/plugins/corsaro_report.c
+++ b/libcorsaro/plugins/corsaro_report.c
@@ -2341,6 +2341,11 @@ static int report_write_libtimeseries(corsaro_plugin_t *p,
         timeseries_kp_set(m->kp, (*pval) + 2, r->pkt_cnt);
         timeseries_kp_set(m->kp, (*pval) + 3, r->bytes);
 
+        if (m->res_handler) {
+            release_corsaro_memhandler_item(m->res_handler, r->memsrc);
+        } else {
+            free(r);
+        }
         JLN(pval, *results, index);
     }
 


### PR DESCRIPTION
We weren't freeing our result structures after we'd written them
out to libtimeseries -- avro output was unaffected and the overall
leaking was small (relative to the amount of memory we do manage
to free each interval), so this flew under the radar a bit :/