### PR TITLE
Emergency fix for OOM when running report plugin

### DIFF
--- a/libcorsaro/plugins/corsaro_report.c
+++ b/libcorsaro/plugins/corsaro_report.c
@@ -2643,6 +2643,7 @@ static int write_all_metrics_avro(corsaro_logger_t *logger,
          * country.
          */
         if ((subtreemask & (1 << (r->metricid >> 32))) == 0) {
+            free(r);
             JLN(pval, *resultmap, index);
             continue;
         }


### PR DESCRIPTION
Note sure how this went unnoticed until now, but it was introduced by the feature to skip results for metric subtrees that are not reported by the tagger at all. We skipped the results, but also forgot to free the memory that had been allocated for them :/