### PR TITLE
flowtuple: merge threads now don't continuously poll for merge jobs

### DIFF
--- a/libcorsaro/plugins/corsaro_flowtuple.c
+++ b/libcorsaro/plugins/corsaro_flowtuple.c
@@ -902,7 +902,12 @@ static void *start_ftmerge_worker(void *tdata) {
     int i;
 
     while (1) {
-        if (zmq_recv(m->inqueue, &(msg), sizeof(msg), 0) < 0) {
+        if (zmq_recv(m->inqueue, &(msg), sizeof(msg), ZMQ_DONTWAIT) < 0) {
+
+            if (errno == EAGAIN) {
+                usleep(1000000);
+                continue;
+            }
             corsaro_log(m->logger, "error receiving message on flowtuple merger thread socket: %s",
                     strerror(errno));
             break;


### PR DESCRIPTION
They just poll once per second now, since a second or two of delay
before we pick up a merging job is not going to be an issue. I'm
much more concerned about wasting CPU on pointless zeromq polling.