### PR TITLE
flowtuple: add a few extra fields to each emitted flowtuple record

### DIFF
--- a/libcorsaro/libcorsaro_filtering.h
+++ b/libcorsaro/libcorsaro_filtering.h
@@ -71,9 +71,7 @@ typedef enum {
      */
     CORSARO_FILTERID_ROUTED,
 
-    /** Matches if the packet looks like one of the various large-scale
-     *  scans that we have identified.
-     */
+    /** Matches if the packet looks like a masscan TCP packet */
     CORSARO_FILTERID_LARGE_SCALE_SCAN,
 
     /** Matches packets that are using a protocol other than TCP, UDP or
@@ -87,6 +85,9 @@ typedef enum {
 
     /** Matches if the packet is a TCP SYN with no options */
     CORSARO_FILTERID_NO_TCP_OPTIONS,
+
+    /** Matches if the packet is a TCP SYN with a receive window of 1024 */
+    CORSARO_FILTERID_TCPWIN_1024,
 
     /** Matches if the packet is an IP fragment */
     CORSARO_FILTERID_FRAGMENT,
@@ -210,6 +211,8 @@ int corsaro_apply_abnormal_protocol_filter(corsaro_logger_t *logger,
 int corsaro_apply_ttl200_filter(corsaro_logger_t *logger,
         libtrace_packet_t *packet);
 int corsaro_apply_no_tcp_options_filter(corsaro_logger_t *logger,
+        libtrace_packet_t *packet);
+int corsaro_apply_tcpwin_1024_filter(corsaro_logger_t *logger,
         libtrace_packet_t *packet);
 int corsaro_apply_fragment_filter(corsaro_logger_t *logger,
         libtrace_packet_t *packet);

--- a/libcorsaro/plugins/corsaro_flowtuple.h
+++ b/libcorsaro/plugins/corsaro_flowtuple.h
@@ -87,19 +87,44 @@ struct corsaro_flowtuple {
   /** Length of the IP packet (from the IP header) */
   uint16_t ip_len;
 
+  /** Size of the TCP SYN (including options) */
+  uint16_t tcp_synlen;
+
+  /** Announced receive window size in the TCP SYN (including options) */
+  uint16_t tcp_synwinlen;
+
   /** The number of packets that comprise this flowtuple
       This is populated immediately before the tuple is written out */
   uint32_t packet_cnt;
+
+  /** The result of applying the hash function to this flowtuple */
   uint32_t hash_val;
 
+  /** Flag indicating whether the source address was probably spoofed */
+  uint8_t is_spoofed;
+
+  /** Flag indicating whether the flow appeared to be a TCP Masscan attempt */
+  uint8_t is_masscan;
+
+  /** Country that the source IP corresponds to, according to maxmind */
   uint16_t maxmind_country;
+  /** Continent that the source IP corresponds to, according to maxmind */
   uint16_t maxmind_continent;
+  /** Country that the source IP corresponds to, according to netacq-edge */
   uint16_t netacq_country;
+  /** Continent that the source IP corresponds to, according to netacq-edge */
   uint16_t netacq_continent;
+  /** ASN that the source IP corresponds to, according to pf2asn data */
   uint32_t prefixasn;
+  /** Bitmap indicating which libipmeta tags are valid for this flow */
   uint16_t tagproviders;
 
+  /** Pointer to local memory manager that allocated this flowtuple (only
+   *  used if tcmalloc is not available.
+   */
   corsaro_memsource_t *memsrc;
+
+  /** Local variables used for merging sorted flowtuple maps */
   size_t pqueue_pos;
   pqueue_pri_t pqueue_pri;
   void *from;

--- a/libcorsaro/plugins/report/merging_thread.c
+++ b/libcorsaro/plugins/report/merging_thread.c
@@ -178,6 +178,8 @@ static inline const char * get_filter_stringname(int fbit) {
             return "non-spoofed.ttl-200";
         case CORSARO_FILTERID_NO_TCP_OPTIONS:
             return "scan.no-tcp-options";
+        case CORSARO_FILTERID_TCPWIN_1024:
+            return "scan.tcp-win-1024";
         case CORSARO_FILTERID_FRAGMENT:
             return "non-spoofed.fragmented-v2";
         case CORSARO_FILTERID_LAST_SRC_IP_0:


### PR DESCRIPTION
**You'll need to rebuild and restart both the tagger and corsarotrace to deploy this change**

The fields that I've added are:
 * TCP SYN length -- the size of the TCP header on the initial SYN
 * TCP SYN window size -- the announced receive window size of the
                          initial SYN
 * "Is spoofed" -- a flag that is set to true if the first packet
                   matches any of the spoofing filters
 * "Is Masscan" -- a flag that is set to true if the first packet
                   matches all of the criteria for detecting TCP
                   Masscan SYNs

Updated the filtering code to add a new filter for TCP SYNs with
an announced window size of 1024, as well as extending the "large
scale scan" filter to match the combined criteria that we have
discovered for masscan so far.

Also fixed a bug in the flowtuple plugin which was causing the TCP
flags for a TCP packet to be derived incorrectly.