### PR TITLE
Add new filter for SIP status messages

### DIFF
--- a/libcorsaro/libcorsaro_filtering.c
+++ b/libcorsaro/libcorsaro_filtering.c
@@ -213,7 +213,7 @@ static inline int _apply_udp_0x31_filter(corsaro_logger_t *logger,
     return 0;
 }
 
-static inline int _apply_sip_error_filter(corsaro_logger_t *logger,
+static inline int _apply_sip_status_filter(corsaro_logger_t *logger,
         filter_params_t *fparams) {
 
   /* uint8_t pattern[9] = {0x53, 0x49, 0x50, 0x2f, 0x32, 0x2e, 0x30, 0x20, 0x34}; */
@@ -235,7 +235,7 @@ static inline int _apply_sip_error_filter(corsaro_logger_t *logger,
 }
 
 static inline int _apply_udp_iplen_96_filter(corsaro_logger_t *logger,
-					     libtrace_ip_t *ip) {
+        libtrace_ip_t *ip) {
 
     if (!ip) {
         return -1;
@@ -784,7 +784,7 @@ static int _apply_erratic_filter(corsaro_logger_t *logger,
         return 1;
     }
 
-    if (_apply_sip_error_filter(logger, fparams) > 0) {
+    if (_apply_sip_status_filter(logger, fparams) > 0) {
         return 1;
     }
 
@@ -967,11 +967,11 @@ int corsaro_apply_udp_0x31_filter(corsaro_logger_t *logger,
     return _apply_udp_0x31_filter(logger, &fparams);
 }
 
-int corsaro_apply_sip_error_filter(corsaro_logger_t *logger,
+int corsaro_apply_sip_status_filter(corsaro_logger_t *logger,
         libtrace_packet_t *packet) {
 
     PREPROCESS_PACKET
-    return _apply_sip_error_filter(logger, &fparams);
+    return _apply_sip_status_filter(logger, &fparams);
 }
 
 int corsaro_apply_udp_iplen_96_filter(corsaro_logger_t *logger,
@@ -1065,8 +1065,8 @@ const char *corsaro_get_builtin_filter_name(corsaro_logger_t *logger,
             return "bittorrent";
         case CORSARO_FILTERID_UDP_0X31:
             return "udp-0x31";
-        case CORSARO_FILTERID_SIP_ERROR:
-            return "sip-error";
+        case CORSARO_FILTERID_SIP_STATUS:
+            return "sip-status";
         case CORSARO_FILTERID_UDP_IPLEN_96:
             return "udp-ip-len-96";
         case CORSARO_FILTERID_PORT_53:
@@ -1198,8 +1198,8 @@ int corsaro_apply_multiple_filters(corsaro_logger_t *logger,
             case CORSARO_FILTERID_UDP_0X31:
                 torun[i].result =_apply_udp_0x31_filter(logger, &fparams);
                 break;
-            case CORSARO_FILTERID_SIP_ERROR:
-                torun[i].result =_apply_sip_error_filter(logger, &fparams);
+            case CORSARO_FILTERID_SIP_STATUS:
+                torun[i].result =_apply_sip_status_filter(logger, &fparams);
                 break;
             case CORSARO_FILTERID_UDP_IPLEN_96:
                 torun[i].result =_apply_udp_iplen_96_filter(logger, fparams.ip);
@@ -1275,8 +1275,8 @@ int corsaro_apply_filter_by_id(corsaro_logger_t *logger,
             return _apply_bittorrent_filter(logger, &fparams);
         case CORSARO_FILTERID_UDP_0X31:
             return _apply_udp_0x31_filter(logger, &fparams);
-        case CORSARO_FILTERID_SIP_ERROR:
-            return _apply_sip_error_filter(logger, &fparams);
+        case CORSARO_FILTERID_SIP_STATUS:
+            return _apply_sip_status_filter(logger, &fparams);
         case CORSARO_FILTERID_UDP_IPLEN_96:
             return _apply_udp_iplen_96_filter(logger, fparams.ip);
         case CORSARO_FILTERID_PORT_53:

--- a/libcorsaro/libcorsaro_filtering.h
+++ b/libcorsaro/libcorsaro_filtering.h
@@ -128,8 +128,8 @@ typedef enum {
     /** Matches UDP packets with a specific payload pattern */
     CORSARO_FILTERID_UDP_0X31,
 
-    /** Matches SIP packets sent over UDP to dest port 5060 over source port 5060 and with a SIP error in the payload */
-    CORSARO_FILTERID_SIP_ERROR,
+    /** Matches SIP packets sent over UDP to dest port 5060 over source port 5060 and with a SIP status-code in the first 7 characters of the payload */
+    CORSARO_FILTERID_SIP_STATUS,
     
     /** Matches UDP packets with an IP length of 96 */
     CORSARO_FILTERID_UDP_IPLEN_96,


### PR DESCRIPTION
Updated the filtering code to add a new filter for UDP packets sent
from source port 5060 to destination port 5060 and containing
"SIP/2.0" in the first 7 characters of the payload. 