### PR TITLE
Fixed yet another source asn set memory leak

### DIFF
--- a/libcorsaro/plugins/report/merging_thread.c
+++ b/libcorsaro/plugins/report/merging_thread.c
@@ -524,6 +524,7 @@ static int report_write_libtimeseries(corsaro_plugin_t *p,
          * country.
          */
         if ((subtreemask & (1 << (r->metricid >> 32))) == 0) {
+            J1FA(judyret, r->uniq_src_asns);
             free(r);
             JLN(pval, *results, index);
             continue;


### PR DESCRIPTION
I'd missed the code path where a metric class (e.g. netacq) is disabled, causing the libtimeseries write to break early.