### PR TITLE
Fix byte ordering of filtbits in the tagger

### DIFF
--- a/corsarotagger/configparser.c
+++ b/corsarotagger/configparser.c
@@ -400,18 +400,6 @@ static int parse_config(void *globalin,
     }
 
     if (key->type == YAML_SCALAR_NODE && value->type == YAML_SCALAR_NODE
-            && !strcmp((char *)key->data.scalar.value, "outputhashbins")) {
-
-        int hbins = (int)strtol((char *)value->data.scalar.value, NULL, 10);
-        if (hbins <= 0 || hbins >= 255) {
-            corsaro_log(logger, "inappropriate number of outputhashbins specified in configuration file: %d, falling back to 4.", hbins);
-            hbins = 4;
-        }
-
-        glob->output_hashbins = (uint8_t)hbins;
-    }
-
-    if (key->type == YAML_SCALAR_NODE && value->type == YAML_SCALAR_NODE
             && !strcmp((char *)key->data.scalar.value, "samplerate")) {
 
         int rate = (int)strtol((char *)value->data.scalar.value, NULL, 10);
@@ -489,10 +477,6 @@ static void log_configuration(corsaro_tagger_global_t *glob) {
                 glob->filterstring);
     }
 
-    corsaro_log(glob->logger,
-            "publishing tagged packets to zeromq at %s using %u hash bins",
-            glob->pubqueuename, glob->output_hashbins);
-
     corsaro_log(glob->logger, "listening for new subscribers at %s",
             glob->control_uri);
 
@@ -555,7 +539,6 @@ corsaro_tagger_global_t *corsaro_tagger_init_global(char *filename,
     glob->filter = NULL;
     glob->logger = NULL;
 
-    glob->output_hashbins = 4;
     glob->sample_rate = 1;
 
     glob->threaddata = NULL;

--- a/corsarotagger/corsarotagger.h
+++ b/corsarotagger/corsarotagger.h
@@ -164,9 +164,6 @@ typedef struct corsaro_tagger_glob {
     /** A zeromq socket for managing new subscribers */
     void *zmq_control;
 
-    /** Number of unique labels to use when streaming tagged packets */
-    uint8_t output_hashbins;
-
     /** ID of the IP meta reloading thread */
     pthread_t ipmeta_reloader;
 

--- a/corsarotagger/tagger_thread.c
+++ b/corsarotagger/tagger_thread.c
@@ -59,13 +59,6 @@
 #include "libcorsaro_tagging.h"
 #include "corsarotagger.h"
 
-#define ASSIGN_HASH_BIN(hash_val, hash_bins, result) { \
-    int hmod; \
-    hmod = hash_val % hash_bins; \
-    if (hmod < 26) {result = 'A' + hmod;} \
-    else {result = 'a' + (hmod - 26); } \
-}
-
 /** Initialises the local data for a tagging thread.
  *
  *  @param tls          The thread-local data to be initialised
@@ -325,11 +318,10 @@ static int tagger_thread_process_buffer(corsaro_tagger_local_t *tls) {
          * to one of our output hash bins, so clients will be able to
          * receive the tagged packets in parallel if they desire.
          */
-        ASSIGN_HASH_BIN(packet->tags.ft_hash,
-                tls->glob->output_hashbins, packet->hashbin);
 
         filtbits = 0;
-        filtbits = (uint16_t)(packet->tags.filterbits & 0x0f);
+        filtbits =(uint16_t)bswap_be_to_host64(packet->tags.filterbits);
+        filtbits = filtbits & 0x0f;
 
         packet->filterbits = htons(filtbits);
         processed += packet->pktlen;

--- a/libcorsaro/libcorsaro_tagging.c
+++ b/libcorsaro/libcorsaro_tagging.c
@@ -685,14 +685,6 @@ int corsaro_update_tagged_loss_tracker(corsaro_tagged_loss_tracker_t *tracker,
 
 	tagid = ntohl(taghdr->tagger_id);
 	thisseq = bswap_be_to_host64(taghdr->seqno);
-
-    /*
-	if (taghdr->hashbin <= 'Z') {
-		seqindex = taghdr->hashbin - 'A';
-	} else {
-		seqindex = taghdr->hashbin - 'a';
-	}
-    */
     seqindex = 0;
 
 	if (tagid != tracker->taggerid) {


### PR DESCRIPTION
Also removes a whole bunch of unnecessary code relating to tagger output hashbins, which are no longer used since the switch to multicast output.