### PR TITLE
Fixes for issues found after deploying the multicast tagger

### DIFF
--- a/corsarotrace/corsarotrace.c
+++ b/corsarotrace/corsarotrace.c
@@ -324,7 +324,7 @@ static libtrace_packet_t * per_packet(libtrace_t *trace,
 
         if (tls->tracker->lostpackets > 0) {
             corsaro_log(glob->logger,
-                    "warning: worker thread %d has observed %lu packets dropped by the tagger in the past interval (%u instances) -- %lu",
+                    "warning: worker thread %d has observed %lu packets dropped in the past interval (%u instances) -- %lu",
                     tls->workerid,
                     tls->tracker->lostpackets, tls->tracker->lossinstances,
                     tls->tracker->packetsreceived);

--- a/libcorsaro/plugins/report/processing_thread.c
+++ b/libcorsaro/plugins/report/processing_thread.c
@@ -416,10 +416,12 @@ int corsaro_report_halt_processing(corsaro_plugin_t *p, void *local) {
     }
 
     /* Wait for the tracker threads to stop */
-    for (i = 0; i < conf->tracker_count; i++) {
-        if (conf->iptrackers[i].tid != 0) {
-            pthread_join(conf->iptrackers[i].tid, NULL);
-            conf->iptrackers[i].tid = 0;
+    if (state->threadid == 0) {
+        for (i = 0; i < conf->tracker_count; i++) {
+            if (conf->iptrackers[i].tid != 0) {
+                pthread_join(conf->iptrackers[i].tid, NULL);
+                conf->iptrackers[i].tid = 0;
+            }
         }
     }
 

--- a/libcorsaro/plugins/report/processing_thread.c
+++ b/libcorsaro/plugins/report/processing_thread.c
@@ -562,9 +562,6 @@ static int process_tags(corsaro_report_tracker_state_t *track,
 
     PROCESS_SINGLE_TAG(CORSARO_METRIC_CLASS_COMBINED, 0, 0);
 
-    tags->providers_used = ntohl(tags->providers_used);
-    tags->filterbits = bswap_be_to_host64(tags->filterbits);
-
     if (!tags || tags->providers_used == 0) {
         return newtags;
     }
@@ -739,6 +736,9 @@ int corsaro_report_process_packet(corsaro_plugin_t *p, void *local,
                 "corsaro_report_process_packet: report thread-local state is NULL!");
         return -1;
     }
+
+    tags->providers_used = ntohl(tags->providers_used);
+    tags->filterbits = bswap_be_to_host64(tags->filterbits);
 
     if (extract_addresses(packet, &srcaddr, &dstaddr, &iplen) != 0) {
         return 0;


### PR DESCRIPTION
 * Fix race condition that sometime would cause corsarotrace to hang when on exit (when using the report plugin).
 * Fix bug where unique destination IP counts for some report metrics were always zero.
 * Fix misleading loss report phrasing in corsarotrace.