### PR TITLE
corsarotrace: add option to write stats to a file

### DIFF
--- a/corsarotrace/configparser.c
+++ b/corsarotrace/configparser.c
@@ -217,6 +217,11 @@ static int parse_remaining_config(corsaro_trace_global_t *glob,
     }
 
     if (key->type == YAML_SCALAR_NODE && value->type == YAML_SCALAR_NODE
+            && !strcmp((char *)key->data.scalar.value, "statfilename")) {
+        glob->statfilename = strdup((char *)value->data.scalar.value);
+    }
+
+    if (key->type == YAML_SCALAR_NODE && value->type == YAML_SCALAR_NODE
             && !strcmp((char *)key->data.scalar.value, "packetsource")) {
         glob->source_uri = strdup((char *)value->data.scalar.value);
     }
@@ -265,6 +270,10 @@ static int parse_remaining_config(corsaro_trace_global_t *glob,
 
 static void log_configuration(corsaro_trace_global_t *glob) {
     corsaro_log(glob->logger, "running on monitor %s", glob->monitorid);
+    if (glob->statfilename) {
+        corsaro_log(glob->logger, "writing statistics to files beginning with '%s'",
+                glob->statfilename);
+    }
     corsaro_log(glob->logger, "interval length is set to %u seconds",
             glob->interval);
     corsaro_log(glob->logger, "rotating files every %u intervals",
@@ -390,6 +399,7 @@ corsaro_trace_global_t *corsaro_trace_init_global(char *filename, int logmode) {
     glob->monitorid = NULL;
     glob->logmode = logmode;
     glob->logfilename = NULL;
+    glob->statfilename = NULL;
     glob->threads = 4;
     glob->plugincount = 0;
 
@@ -520,6 +530,10 @@ void corsaro_trace_free_global(corsaro_trace_global_t *glob) {
 
     if (glob->template) {
         free(glob->template);
+    }
+
+    if (glob->statfilename) {
+        free(glob->statfilename);
     }
 
     if (glob->logfilename) {

--- a/corsarotrace/corsarotrace.h
+++ b/corsarotrace/corsarotrace.h
@@ -95,6 +95,7 @@ typedef struct corsaro_trace_glob {
     corsaro_logger_t *logger;
     char *template;
     char *logfilename;
+    char *statfilename;
     char *source_uri;
     char *filterstring;
     char *monitorid;


### PR DESCRIPTION
The "stats" file works the same way it does for corsarotagger.

For each interval, each thread writes its stats for that interval
to a uniquely named stats file. The stats are overwritten at each
interval, so if they aren't scraped before the next interval then
they will be lost (this copies the tagger behaviour).

The stats that corsarotrace will write are:
 * interval timestamp
 * number of packets received by that thread
 * number of packets detected as dropped by that thread
 * number of instances of packet loss detected by that thread
   (a loss instance may result in multiple packets being lost)
 * number of packets seen that should have been seen during an
   earlier interval (indicates packet reordering is happening).