### PR TITLE
More report plugin performance enhancements

### DIFF
--- a/libcorsaro/libcorsaro_tagging.c
+++ b/libcorsaro/libcorsaro_tagging.c
@@ -707,7 +707,11 @@ int corsaro_update_tagged_loss_tracker(corsaro_tagged_loss_tracker_t *tracker,
 	 * as "unknown".
 	 */
 	if (tracker->nextseq != 0 && thisseq != tracker->nextseq) {
-		tracker->lostpackets += (thisseq - tracker->nextseq);
+        if (thisseq > tracker->nextseq) {
+    		tracker->lostpackets += (thisseq - tracker->nextseq);
+        } else {
+            tracker->lostpackets += 1;
+        }
 		tracker->lossinstances ++;
 	}
     tracker->packetsreceived ++;

--- a/libcorsaro/plugins/report/corsaro_report.c
+++ b/libcorsaro/plugins/report/corsaro_report.c
@@ -448,11 +448,9 @@ int corsaro_report_finalise_config(corsaro_plugin_t *p,
         pthread_mutex_init(&(conf->iptrackers[i].mutex), NULL);
         conf->iptrackers[i].lastresultts = 0;
 
-        conf->iptrackers[i].knownips = NULL;
-        conf->iptrackers[i].knownips_next = NULL;
-        conf->iptrackers[i].lastresult = NULL;
-        conf->iptrackers[i].currentresult = NULL;
-        conf->iptrackers[i].nextresult = NULL;
+        conf->iptrackers[i].prev_maps = NULL;
+        conf->iptrackers[i].curr_maps = NULL;
+        conf->iptrackers[i].next_maps = NULL;
         conf->iptrackers[i].logger = p->logger;
         conf->iptrackers[i].sourcethreads = stdopts->procthreads;
         conf->iptrackers[i].haltphase = 0;

--- a/libcorsaro/plugins/report/merging_thread.c
+++ b/libcorsaro/plugins/report/merging_thread.c
@@ -656,6 +656,7 @@ static void clean_result_map(Pvoid_t *resultmap) {
     JLF(pval, *resultmap, index);
     while (pval) {
         r = (corsaro_report_result_t *)(*pval);
+        J1FA(judyret, r->uniq_src_asns);
         free(r);
         JLN(pval, *resultmap, index);
     }

--- a/libcorsaro/plugins/report/merging_thread.c
+++ b/libcorsaro/plugins/report/merging_thread.c
@@ -759,6 +759,54 @@ static int initialise_results(corsaro_plugin_t *p, Pvoid_t *results,
     return 0;
 }
 
+static void update_merged_metric(Pvoid_t *results,
+        corsaro_metric_ip_hash_t *iphash, corsaro_report_config_t *conf,
+        uint64_t metricid, uint32_t ts, uint32_t *subtrees_seen) {
+
+    corsaro_report_result_t *r;
+    PWord_t pval;
+    Word_t index = 0, ret;
+    int x;
+
+    *subtrees_seen = (*subtrees_seen) | (1 << (metricid >> 32));
+
+    JLG(pval, *results, metricid);
+    if (pval == NULL) {
+        /* This is a new metric, add it to our result hash map */
+        r = new_result(metricid, conf->outlabel, ts);
+        JLI(pval, *results, metricid);
+        *pval = (Word_t)r;
+    } else {
+        r = (corsaro_report_result_t *)(*pval);
+    }
+
+    J1C(ret, iphash->srcips, 0, -1);
+    r->uniq_src_ips += (uint32_t)ret;
+    J1C(ret, iphash->destips, 0, -1);
+    r->uniq_dst_ips += (uint32_t)ret;
+
+    /* Consider limiting this to only certain metrics if processing
+     * time becomes a problem?
+     */
+    index = 0;
+    if (iphash->srcasns != NULL) {
+        J1F(x, iphash->srcasns, index);
+        while (x) {
+            J1S(x, r->uniq_src_asns, (Word_t)index);
+            if (x != 0) {
+                r->uniq_src_asn_count ++;
+            }
+            J1N(x, iphash->srcasns, index);
+        }
+        J1FA(ret, iphash->srcasns);
+    }
+
+    r->pkt_cnt += iphash->packets;
+    r->bytes += iphash->bytes;
+
+    J1FA(ret, iphash->srcips);
+    J1FA(ret, iphash->destips);
+}
 
 /** Update the merged result set for an interval with a set of completed
  *  tallies from an IP tracker thread.
@@ -776,66 +824,80 @@ static void update_tracker_results(Pvoid_t *results,
         corsaro_report_config_t *conf,  uint32_t *subtrees_seen,
         corsaro_logger_t *logger) {
 
-    corsaro_report_result_t *r;
     corsaro_metric_ip_hash_t *iter;
-    PWord_t pval, pval2;
-    Word_t index = 0, index2 = 0, ret;
-    int x;
+    PWord_t pval;
+    Word_t index = 0, ret;
+    int i;
+    uint64_t metid;
 
     /* Simple loop over all metrics in the tracker tally and update our
      * combined metric map.
      */
 
-    JLF(pval, tracker->lastresult, index);
+    assert(tracker->prev_maps != NULL);
+    metid = CORSARO_METRIC_CLASS_COMBINED;
+    metid = (metid << 32);
+    update_merged_metric(results, &(tracker->prev_maps->combined), conf,
+            metid, ts, subtrees_seen);
+
+    if (tracker->prev_maps->ipprotocols) {
+        metid = CORSARO_METRIC_CLASS_IP_PROTOCOL;
+        metid = (metid << 32);
+        for (i = 0; i < 256; i++) {
+            update_merged_metric(results, &(tracker->prev_maps->ipprotocols[i]),
+                    conf, (metid | i), ts, subtrees_seen);
+        }
+        free(tracker->prev_maps->ipprotocols);
+    }
+
+    if (tracker->prev_maps->filters) {
+        metid = CORSARO_METRIC_CLASS_FILTER_CRITERIA;
+        metid = (metid << 32);
+        for (i = CORSARO_FILTERID_ABNORMAL_PROTOCOL; i < CORSARO_FILTERID_MAX;
+                i++) {
+            update_merged_metric(results,
+                    &(tracker->prev_maps->filters[i]), conf, (metid | i), ts,
+                    subtrees_seen);
+        }
+        free(tracker->prev_maps->filters);
+    }
+
+    if (tracker->prev_maps->tcpsrc) {
+        metid = CORSARO_METRIC_CLASS_TCP_SOURCE_PORT;
+        metid = (metid << 32);
+        for (i = 0; i < 65536; i++) {
+            update_merged_metric(results,
+                    &(tracker->prev_maps->tcpsrc[i]), conf, (metid | i), ts,
+                    subtrees_seen);
+        }
+        free(tracker->prev_maps->tcpsrc);
+    }
+
+    if (tracker->prev_maps->tcpdst) {
+        metid = CORSARO_METRIC_CLASS_TCP_DEST_PORT;
+        metid = (metid << 32);
+        for (i = 0; i < 65536; i++) {
+            update_merged_metric(results,
+                    &(tracker->prev_maps->tcpdst[i]), conf, (metid | i), ts,
+                    subtrees_seen);
+        }
+        free(tracker->prev_maps->tcpdst);
+    }
+
+    JLF(pval, tracker->prev_maps->general, index);
     while (pval) {
         iter = (corsaro_metric_ip_hash_t *)(*pval);
 
-        *subtrees_seen = (*subtrees_seen) | (1 << (iter->metricid >> 32));
-
-        JLG(pval2, *results, iter->metricid);
-        if (pval2 == NULL) {
-            /* This is a new metric, add it to our result hash map */
-            r = new_result(iter->metricid, conf->outlabel, ts);
-            JLI(pval2, *results, iter->metricid);
-            *pval2 = (Word_t)r;
-        } else {
-            r = (corsaro_report_result_t *)(*pval2);
-        }
-
-        J1C(ret, iter->srcips, 0, -1);
-        r->uniq_src_ips += (uint32_t)ret;
-        J1C(ret, iter->destips, 0, -1);
-        r->uniq_dst_ips += (uint32_t)ret;
-
-        /* Consider limiting this to only certain metrics if processing
-         * time becomes a problem?
-         */
-        index2 = 0;
-        if (iter->srcasns != NULL) {
-            J1F(x, iter->srcasns, index2);
-            while (x) {
-                J1S(x, r->uniq_src_asns, (Word_t)index2);
-                if (x != 0) {
-                    r->uniq_src_asn_count ++;
-                }
-                J1N(x, iter->srcasns, index2);
-            }
-            J1FA(ret, iter->srcasns);
-        }
-
-        r->pkt_cnt += iter->packets;
-        r->bytes += iter->bytes;
-
-        /* Don't forget to release the metric tally back to the IP tracker */
-        J1FA(ret, iter->srcips);
-        J1FA(ret, iter->destips);
+        update_merged_metric(results, iter, conf, iter->metricid, ts,
+                subtrees_seen);
         free(iter);
 
-        JLN(pval, tracker->lastresult, index);
+        JLN(pval, tracker->prev_maps->general, index);
     }
 
-    JLFA(ret, tracker->lastresult);
-    tracker->lastresult = NULL;
+    JLFA(ret, tracker->prev_maps->general);
+    free(tracker->prev_maps);
+    tracker->prev_maps = NULL;
 }
 
 

--- a/libcorsaro/plugins/report/report_internal.h
+++ b/libcorsaro/plugins/report/report_internal.h
@@ -152,6 +152,8 @@ typedef struct corsaro_metric_ip_hash_t {
      *  are the metric value. */
     uint64_t metricid;
 
+    uint64_t associated_metricids[8];
+
     /** Unique source IPs associated with this metric */
     Pvoid_t srcips;
 
@@ -192,6 +194,16 @@ typedef struct corsaro_report_outstanding_interval {
     uint8_t reports_total;
 } corsaro_report_out_interval_t;
 
+typedef struct corsaro_report_iptracker_maps {
+    corsaro_metric_ip_hash_t combined;
+
+    corsaro_metric_ip_hash_t *ipprotocols;
+    corsaro_metric_ip_hash_t *filters;
+    corsaro_metric_ip_hash_t *tcpsrc;
+    corsaro_metric_ip_hash_t *tcpdst;
+
+    Pvoid_t general;
+} corsaro_report_iptracker_maps_t;
 
 /** Structure to store state for an IP tracker thread */
 typedef struct corsaro_report_iptracker {
@@ -218,19 +230,9 @@ typedef struct corsaro_report_iptracker {
     /** Mutex used to protect the most recent complete tally */
     pthread_mutex_t mutex;
 
-    /** Hash map of all IP addresses observed for the current interval */
-    Pvoid_t knownips;
-
-    /** Hash map of all IP addresses observed that should be counted towards
-     *  the next interval.
-     */
-    Pvoid_t knownips_next;
-
-    /** Hash map containing the most recent complete metric tallies */
-    Pvoid_t lastresult;
-
-    /** Hash map containing the ongoing tallies for the current interval */
-    Pvoid_t currentresult;
+    corsaro_report_iptracker_maps_t *prev_maps;
+    corsaro_report_iptracker_maps_t *curr_maps;
+    corsaro_report_iptracker_maps_t *next_maps;
 
     /** Hash map containing the ongoing tallies for tags that should be
      *  counted towards the next interval. */

--- a/libcorsaro/plugins/report/report_internal.h
+++ b/libcorsaro/plugins/report/report_internal.h
@@ -86,6 +86,11 @@
 /** Maximum number of IP tracker threads allowed */
 #define CORSARO_REPORT_MAX_IPTRACKERS (32)
 
+/** Maximum depth of sub-classification for hierarchical metrics, e.g. geolocation metrics
+ *  have a hierarchy of continent, country, region, county, ... etc
+ */
+#define MAX_ASSOCIATED_METRICS (8)
+
 /* Note: these pre-defined alpha-2 codes are used to bootstrap the
  * results data so that we can reliably report 0 values for countries
  * that do not appear in a given interval, even if we've never seen that
@@ -152,7 +157,7 @@ typedef struct corsaro_metric_ip_hash_t {
      *  are the metric value. */
     uint64_t metricid;
 
-    uint64_t associated_metricids[8];
+    uint64_t associated_metricids[MAX_ASSOCIATED_METRICS];
 
     /** Unique source IPs associated with this metric */
     Pvoid_t srcips;
@@ -205,6 +210,17 @@ typedef struct corsaro_report_iptracker_maps {
     Pvoid_t general;
 } corsaro_report_iptracker_maps_t;
 
+typedef struct corsaro_report_savedtags {
+    uint64_t associated_metricids[MAX_ASSOCIATED_METRICS];
+    uint64_t next_saved;
+
+    uint32_t srcip;
+    uint32_t destip;
+    uint32_t srcasn;
+    uint32_t bytes;
+    uint32_t packets;
+} corsaro_report_savedtags_t;
+
 /** Structure to store state for an IP tracker thread */
 typedef struct corsaro_report_iptracker {
 
@@ -233,6 +249,8 @@ typedef struct corsaro_report_iptracker {
     corsaro_report_iptracker_maps_t *prev_maps;
     corsaro_report_iptracker_maps_t *curr_maps;
     corsaro_report_iptracker_maps_t *next_maps;
+
+    corsaro_report_savedtags_t netacq_saved;
 
     /** Hash map containing the ongoing tallies for tags that should be
      *  counted towards the next interval. */


### PR DESCRIPTION
The main goal here has been to reduce the number of lookups in the "metric map" that the IP tracker threads use to accumulate packet counts and unique IPs + ASNs for each metric that we care about.

There are two key changes here:
 1. metrics where the range of possible values is finite and densely populated are now tracked in conventional arrays rather than a Judy array. This covers the metrics for IP protocols, TCP ports, the individual filter criteria and the "combined" metric.
 2. Netacuity geolocation metrics are now only tracked for the most-specific location tag for each observed packet. This will be county for US locations and region for most other countries. The corresponding less specific tags (e.g. continent, country, region for US locations) are instead noted alongside the more-specific location tag within the map entry itself. This means that instead of doing up to 4 map lookups per IP address, we will now do just the one. The appropriate results for the less-specific location tags can still be derived from the results for the more-specific ones, so we don't lose anything here in terms of the final result (hopefully!).

Also fixed a couple of other bugs along the way:
 * corsarotrace should no longer report obscenely large numbers of lost packets when a reordering event occurs.
 * the report plugin should no longer leak the unique ASN maps for each metric observed in the first interval. 