### PR TITLE
Re-add `threads` option for corsarotrace

### DIFF
--- a/corsarotrace/configparser.c
+++ b/corsarotrace/configparser.c
@@ -242,6 +242,11 @@ static int parse_remaining_config(corsaro_trace_global_t *glob,
     }
 
     if (key->type == YAML_SCALAR_NODE && value->type == YAML_SCALAR_NODE
+        && !strcmp((char *)key->data.scalar.value, "threads")) {
+        glob->threads = strtoul((char *)value->data.scalar.value, NULL, 10);
+    }
+
+    if (key->type == YAML_SCALAR_NODE && value->type == YAML_SCALAR_NODE
             && !strcmp((char *)key->data.scalar.value, "startboundaryts")) {
         glob->boundstartts = strtoul((char *)value->data.scalar.value, NULL, 10);
     }

--- a/corsarotrace/corsarotrace.c
+++ b/corsarotrace/corsarotrace.c
@@ -861,7 +861,6 @@ int main(int argc, char *argv[]) {
         glob->threads = ctrlreply.hashbins;
     } else {
         glob->control_uri = strdup(INTERNAL_ZMQ_CONTROL_URI);
-        glob->threads = 4;
         pthread_create(&fauxcontrol, NULL, start_faux_control_thread, glob);
         corsaro_log(glob->logger, "started faux tagger control thread");
     }

--- a/docs/corsarotrace-README.md
+++ b/docs/corsarotrace-README.md
@@ -89,11 +89,11 @@ The full set of supported global config options is:
                           ends up in a single file).
 
     threads               The number of processing threads to use to receive
-                          and write packets. Only used when consuming
-                          packets from a separate tagger instance. If
-                          using the tagproviders option (i.e., no
-                          controlsocketname option), this setting will
-                          be ignored.
+                          and write packets. Only used when processing
+                          in "offline" mode (i.e., not consuming
+                          packets from a separate tagger instance). If
+                          the controlsocketname option is used, this
+                          setting will be ignored.
 
     startboundaryts       Ignore all packets that have a timestamp earlier than
                           the Unix timestamp specified for this option.

--- a/docs/corsarotrace-README.md
+++ b/docs/corsarotrace-README.md
@@ -88,6 +88,13 @@ The full set of supported global config options is:
                           set to 0, no file rotation is performed (all output
                           ends up in a single file).
 
+    threads               The number of processing threads to use to receive
+                          and write packets. Only used when consuming
+                          packets from a separate tagger instance. If
+                          using the tagproviders option (i.e., no
+                          controlsocketname option), this setting will
+                          be ignored.
+
     startboundaryts       Ignore all packets that have a timestamp earlier than
                           the Unix timestamp specified for this option.
 
@@ -215,7 +222,13 @@ The flowtuple plugin can be further configured using the following options:
 
     mergethreads          Specifies the number of threads to reserve for
                           merging flowtuple results into a single coherent
-                          file. Defaults to 2.
+                          file. If this is less than the number of
+                          corsarotrace processing threads it will be
+                          ignored. If it is more than the number of
+                          processing threads, the merge threads will
+                          operate as a thread pool, but note that the
+                          output files will not have consistent
+                          thread IDs appended to their names.
 
     avrooutput            If set to 'snappy', the avro files produced as
                           interim output will be compressed using the snappy

--- a/libcorsaro/plugins/corsaro_flowtuple.c
+++ b/libcorsaro/plugins/corsaro_flowtuple.c
@@ -412,6 +412,14 @@ int corsaro_flowtuple_finalise_config(corsaro_plugin_t *p,
     conf->basic.monitorid = stdopts->monitorid;
     conf->zmq_ctxt = zmq_ctxt;
 
+    if (conf->maxmergeworkers < stdopts->procthreads) {
+      corsaro_log(p->logger,
+                "flowtuple plugin: mergethreads (%d) is less than procthreads "
+                  "(%d) and will be ignored.", conf->maxmergeworkers,
+                  stdopts->procthreads);
+      conf->maxmergeworkers = stdopts->procthreads;
+    }
+
     corsaro_log(p->logger, "flowtuple plugin: using %u merging threads",
             conf->maxmergeworkers);
     if (conf->sort_enabled == CORSARO_FLOWTUPLE_SORT_ENABLED) {


### PR DESCRIPTION
This allows the number of processing threads to be explicitly configured when using corsarotrace in "offline" mode. It also adds a sanity check to the flowtuple plugin in case the number of merge threads is less than the number of processing threads.