### PR TITLE
Report plugin: add ability to limit TCP and UDP port series to specific port numbers or ranges

### DIFF
--- a/docs/corsarotrace-README.md
+++ b/docs/corsarotrace-README.md
@@ -368,6 +368,18 @@ The report plugin supports the following configuration options:
                           metric labels may contain a lot of 'unknown's. Default
                           is 'yes'.
 
+    tcp_source_port_range These options can be used to limit the collection
+    tcp_dest_port_range   of time series data for TCP and UDP ports to
+    udp_source_port_range specific port ranges. The port ranges are specified
+    udp_dest_port_range   as a sequence (to allow for multiple non-overlapping
+                          ranges), where each sequence item must be a
+                          start port, followed by a '-', followed by an end
+                          port. The ranges are considered as inclusive, so a
+                          range of "0-1024" will include both port 0 and port
+                          1024. If a range option is absent for a particular
+                          port metric, then results are produced for all
+                          65536 possible port numbers for that metric.
+
 
 corsarotrace Tag Providers
 ==========================

--- a/docs/corsarotrace-README.md
+++ b/docs/corsarotrace-README.md
@@ -374,11 +374,13 @@ The report plugin supports the following configuration options:
     udp_dest_port_range   as a sequence (to allow for multiple non-overlapping
                           ranges), where each sequence item must be a
                           start port, followed by a '-', followed by an end
-                          port. The ranges are considered as inclusive, so a
-                          range of "0-1024" will include both port 0 and port
-                          1024. If a range option is absent for a particular
-                          port metric, then results are produced for all
-                          65536 possible port numbers for that metric.
+                          port. Ranges consisting of a single port may be
+                          expressed using just the port number, without a '-'
+                          or an end port. The ranges are considered as
+                          inclusive, so a range of "0-1024" will include both
+                          port 0 and port 1024. If a range option is absent fo
+                          a particular port metric, then results are produced
+                          for all 65536 possible port numbers for that metric.
 
 
 corsarotrace Tag Providers

--- a/exampleconfigs/reportconfig.yaml
+++ b/exampleconfigs/reportconfig.yaml
@@ -101,10 +101,10 @@ plugins:
       iptracker_threads: 4
 
       # This option limits the collection of time series data to specific
-      # subsets of TCP source ports (in this case, 0-1024 inclusive and
-      # 10000-12000 inclusive). If not present, series data will be produced
-      # for all TCP source ports (assuming 'tcpports' is not disabled using
-      # the limitmetrics option).
+      # subsets of TCP source ports (in this case, 0-1024 inclusive,
+      # 10000-12000 inclusive and port 22444 alone). If not present, series data
+      # will be produced for all TCP source ports (assuming 'tcpports' is not
+      # disabled using the limitmetrics option).
       #
       # Config options also exist for 'tcp_dest_port_range',
       # 'udp_source_port_range' and 'udp_dest_port_range', which work in the
@@ -112,6 +112,7 @@ plugins:
       tcp_source_port_range:
         - 0-1024
         - 10000-12000
+        - 22444
 
       # This option will limit our processing to a specific set of metrics.
       # If not specified, all metrics will be produced. See README for a

--- a/exampleconfigs/reportconfig.yaml
+++ b/exampleconfigs/reportconfig.yaml
@@ -100,6 +100,19 @@ plugins:
       # IPs for each metric.
       iptracker_threads: 4
 
+      # This option limits the collection of time series data to specific
+      # subsets of TCP source ports (in this case, 0-1024 inclusive and
+      # 10000-12000 inclusive). If not present, series data will be produced
+      # for all TCP source ports (assuming 'tcpports' is not disabled using
+      # the limitmetrics option).
+      #
+      # Config options also exist for 'tcp_dest_port_range',
+      # 'udp_source_port_range' and 'udp_dest_port_range', which work in the
+      # same way as this option.
+      tcp_source_port_range:
+        - 0-1024
+        - 10000-12000
+
       # This option will limit our processing to a specific set of metrics.
       # If not specified, all metrics will be produced. See README for a
       # list of suitable terms that can be used here and what metrics they

--- a/libcorsaro/plugins/report/corsaro_report.c
+++ b/libcorsaro/plugins/report/corsaro_report.c
@@ -207,27 +207,28 @@ static void parse_port_ranges(uint8_t *port_array, yaml_document_t *doc,
         for (index = firstindex; index < 8192; index ++) {
             int msb = index * 8;
             int lsb = msb + 7;
+            uint8_t toadd = 0xff;
 
             if (msb > last) {
                 break;
             }
 
-            port_array[index] = 0xff;
             if (first > msb) {
                 if (first - msb >= 8) {
-                    port_array[index] = 0;
+                    toadd = 0;
                 } else {
-                    port_array[index] &= ((0xff) >> (first - msb));
+                    toadd &= ((0xff) >> (first - msb));
                 }
             }
 
             if (last < lsb) {
                 if (lsb - last >= 8) {
-                    port_array[index] = 0;
+                    toadd = 0;
                 } else {
-                    port_array[index] &= ((0xff) << (lsb - last));
+                    toadd &= ((0xff) << (lsb - last));
                 }
             }
+            port_array[index] |= toadd;
         }
     }
 }

--- a/libcorsaro/plugins/report/corsaro_report.c
+++ b/libcorsaro/plugins/report/corsaro_report.c
@@ -139,6 +139,99 @@ corsaro_plugin_t *corsaro_report_alloc(void) {
     return &(corsaro_report_plugin);
 }
 
+static void parse_port_ranges(uint8_t *port_array, yaml_document_t *doc,
+        yaml_node_t *rangelist, bool *seen_flag, corsaro_logger_t *logger) {
+
+    yaml_node_item_t *item;
+    for (item = rangelist->data.sequence.items.start;
+            item != rangelist->data.sequence.items.top; item++) {
+        yaml_node_t *node = yaml_document_get_node(doc, *item);
+        char *range, *dash = NULL;
+        unsigned long int first, last;
+        int index = 0, firstindex = 0;
+
+        if (node->type != YAML_SCALAR_NODE) {
+            corsaro_log(logger, "Invalid YAML configuration for a portrange option -- ignoring");
+            return;
+        }
+        range = (char *)node->data.scalar.value;
+
+        dash = strchr(range, '-');
+        if (dash == NULL) {
+            corsaro_log(logger, "Invalid format for portrange option, must be '<first>-<last>'");
+            continue;
+        }
+
+        *dash = '\0';
+        errno = 0;
+        first = strtoul(range, NULL, 0);
+        if (errno != 0) {
+            corsaro_log(logger, "Error converting '%s' to port number: %s",
+                    range, strerror(errno));
+            *dash = '-';
+            continue;
+        }
+
+        if (first > 65535) {
+            corsaro_log(logger, "Invalid port number in portrange option '%s'",
+                    range);
+            *dash = '-';
+            continue;
+        }
+
+        *dash = '-';
+        errno = 0;
+        last = strtoul(dash + 1, NULL, 0);
+        if (errno != 0) {
+            corsaro_log(logger, "Error converting '%s' to port number: %s",
+                    dash+1, strerror(errno));
+            continue;
+        }
+
+        if (last > 65535) {
+            last = 65535;
+        }
+        if (last < first) {
+            corsaro_log(logger, "Invalid port range configuration '%s' -- first port must be <= the last port", range);
+            continue;
+        }
+
+        if (*seen_flag == false) {
+            memset(port_array, 0, 8192 * sizeof(uint8_t));
+            *seen_flag = true;
+        }
+
+        corsaro_log(logger, "Setting port range to %u : %u", first, last);
+
+        firstindex = (first / 8);
+        for (index = firstindex; index < 8192; index ++) {
+            int msb = index * 8;
+            int lsb = msb + 7;
+
+            if (msb > last) {
+                break;
+            }
+
+            port_array[index] = 0xff;
+            if (first > msb) {
+                if (first - msb >= 8) {
+                    port_array[index] = 0;
+                } else {
+                    port_array[index] &= ((0xff) >> (first - msb));
+                }
+            }
+
+            if (last < lsb) {
+                if (lsb - last >= 8) {
+                    port_array[index] = 0;
+                } else {
+                    port_array[index] &= ((0xff) << (lsb - last));
+                }
+            }
+        }
+    }
+}
+
 static void parse_metric_limits(corsaro_report_config_t *conf,
         yaml_document_t *doc, yaml_node_t *metlist, corsaro_logger_t *logger) {
 
@@ -213,6 +306,10 @@ int corsaro_report_parse_config(corsaro_plugin_t *p, yaml_document_t *doc,
     corsaro_report_config_t *conf;
     yaml_node_t *key, *value;
     yaml_node_pair_t *pair;
+    bool set_tcp_src_ports = false;
+    bool set_udp_src_ports = false;
+    bool set_tcp_dest_ports = false;
+    bool set_udp_dest_ports = false;
 
     conf = (corsaro_report_config_t *)malloc(sizeof(corsaro_report_config_t));
     if (conf == NULL) {
@@ -254,6 +351,38 @@ int corsaro_report_parse_config(corsaro_plugin_t *p, yaml_document_t *doc,
                 free(conf->outlabel);
             }
             conf->outlabel = strdup(val);
+        }
+
+        if (key->type == YAML_SCALAR_NODE && value->type == YAML_SEQUENCE_NODE
+                    && strcmp((char *)key->data.scalar.value,
+                            "tcp_source_port_range") == 0) {
+            parse_port_ranges(conf->allowedports.tcp_sources, doc, value,
+                    &set_tcp_src_ports, p->logger);
+
+        }
+
+        if (key->type == YAML_SCALAR_NODE && value->type == YAML_SEQUENCE_NODE
+                    && strcmp((char *)key->data.scalar.value,
+                            "tcp_dest_port_range") == 0) {
+            parse_port_ranges(conf->allowedports.tcp_dests, doc, value,
+                    &set_tcp_dest_ports, p->logger);
+
+        }
+
+        if (key->type == YAML_SCALAR_NODE && value->type == YAML_SEQUENCE_NODE
+                    && strcmp((char *)key->data.scalar.value,
+                            "udp_source_port_range") == 0) {
+            parse_port_ranges(conf->allowedports.udp_sources, doc, value,
+                    &set_udp_src_ports, p->logger);
+
+        }
+
+        if (key->type == YAML_SCALAR_NODE && value->type == YAML_SEQUENCE_NODE
+                    && strcmp((char *)key->data.scalar.value,
+                            "udp_dest_port_range") == 0) {
+            parse_port_ranges(conf->allowedports.udp_dests, doc, value,
+                    &set_udp_dest_ports, p->logger);
+
         }
 
         if (key->type == YAML_SCALAR_NODE && value->type == YAML_SEQUENCE_NODE
@@ -316,6 +445,22 @@ int corsaro_report_parse_config(corsaro_plugin_t *p, yaml_document_t *doc,
                 conf->outformat = CORSARO_OUTPUT_AVRO;
            }
         }
+    }
+
+    /* If no specific port ranges are given, then default to reporting
+     * time series for ALL ports
+     */
+    if (set_tcp_src_ports == false) {
+        memset(conf->allowedports.tcp_sources, 0xff, sizeof(uint8_t) * 8192);
+    }
+    if (set_tcp_dest_ports == false) {
+        memset(conf->allowedports.tcp_dests, 0xff, sizeof(uint8_t) * 8192);
+    }
+    if (set_udp_src_ports == false) {
+        memset(conf->allowedports.udp_sources, 0xff, sizeof(uint8_t) * 8192);
+    }
+    if (set_udp_dest_ports == false) {
+        memset(conf->allowedports.udp_dests, 0xff, sizeof(uint8_t) * 8192);
     }
 
     p->config = conf;

--- a/libcorsaro/plugins/report/iptracker_thread.c
+++ b/libcorsaro/plugins/report/iptracker_thread.c
@@ -111,20 +111,6 @@ static void update_knownip_metric(corsaro_report_iptracker_t *track,
         }
         assert(filterid < CORSARO_FILTERID_MAX);
         m = &(maps->filters[filterid]);
-    } else if (metricclass == CORSARO_METRIC_CLASS_TCP_SOURCE_PORT) {
-        uint64_t portnum = (metricid & 0xFFFFFFFF);
-        if (maps->tcpsrc == NULL) {
-            maps->tcpsrc = calloc(65536, sizeof(corsaro_metric_ip_hash_t));
-        }
-        assert(portnum < 65536);
-        m = &(maps->tcpsrc[portnum]);
-    } else if (metricclass == CORSARO_METRIC_CLASS_TCP_DEST_PORT) {
-        uint64_t portnum = (metricid & 0xFFFFFFFF);
-        if (maps->tcpdst == NULL) {
-            maps->tcpdst = calloc(65536, sizeof(corsaro_metric_ip_hash_t));
-        }
-        assert(portnum < 65536);
-        m = &(maps->tcpdst[portnum]);
     } else if (metricclass == CORSARO_METRIC_CLASS_NETACQ_CONTINENT ||
             metricclass == CORSARO_METRIC_CLASS_NETACQ_COUNTRY ||
             metricclass == CORSARO_METRIC_CLASS_NETACQ_REGION ||
@@ -286,20 +272,6 @@ static void free_map_set(corsaro_report_iptracker_maps_t *maps) {
             free_metrichash(&(maps->filters[i]));
         }
         free(maps->filters);
-    }
-
-    if (maps->tcpsrc) {
-        for (i = 0; i < 65536; i++) {
-            free_metrichash(&(maps->tcpsrc[i]));
-        }
-        free(maps->tcpsrc);
-    }
-
-    if (maps->tcpdst) {
-        for (i = 0; i < 65536; i++) {
-            free_metrichash(&(maps->tcpdst[i]));
-        }
-        free(maps->tcpdst);
     }
 
     free_metrichash(&(maps->combined));

--- a/libcorsaro/plugins/report/report_internal.h
+++ b/libcorsaro/plugins/report/report_internal.h
@@ -204,8 +204,6 @@ typedef struct corsaro_report_iptracker_maps {
 
     corsaro_metric_ip_hash_t *ipprotocols;
     corsaro_metric_ip_hash_t *filters;
-    corsaro_metric_ip_hash_t *tcpsrc;
-    corsaro_metric_ip_hash_t *tcpdst;
 
     Pvoid_t general;
 } corsaro_report_iptracker_maps_t;
@@ -279,6 +277,12 @@ typedef struct corsaro_report_iptracker {
     uint64_t allowedmetricclasses;
 } corsaro_report_iptracker_t;
 
+typedef struct allowed_ports {
+    uint8_t tcp_sources[8192];
+    uint8_t tcp_dests[8192];
+    uint8_t udp_sources[8192];
+    uint8_t udp_dests[8192];
+} allowed_ports_t;
 
 /** Structure describing configuration specific to the report plugin */
 typedef struct corsaro_report_config {
@@ -328,6 +332,10 @@ typedef struct corsaro_report_config {
      *  re-think this approach.
      */
     uint64_t allowedmetricclasses;
+
+    /** TCP and UDP ports for which we are going to track per-port statistics.
+     */
+    allowed_ports_t allowedports;
 } corsaro_report_config_t;
 
 


### PR DESCRIPTION
Rather than naively producing 65536 time series for each port metric, we now have the ability to limit the number of series that we produce to specific ports that are "interesting".

This will both decrease our general workload when running the report plugin, as well as lowering our daily storage requirements.