### PR TITLE
Add option to limit geo-tagged time series to continent and country only

### DIFF
--- a/docs/corsarotrace-README.md
+++ b/docs/corsarotrace-README.md
@@ -360,6 +360,11 @@ The report plugin supports the following configuration options:
                           - "filter": include the individual filter matching
                                       metrics
 
+    geo_mode              If set to 'lite', geo-tagging metrics will be limited
+                          to continent and country-level tagging only. Regions,
+                          polygons and counties will be disabled. If set to
+                          'full', all geo-tagging metrics will be reported.
+
     querytaggerlabels     If set to 'no', the plugin will NOT attempt to ask
                           the tagger for FQ labels for each country, region,
                           etc. that appears in the geo-location tags. This is

--- a/exampleconfigs/reportconfig.yaml
+++ b/exampleconfigs/reportconfig.yaml
@@ -114,6 +114,10 @@ plugins:
         - 10000-12000
         - 22444
 
+      # Set to 'lite' to disable geo-tagging for regions, polygons and
+      # counties. Continent and country series will still be reported.
+      geo_mode: full
+
       # This option will limit our processing to a specific set of metrics.
       # If not specified, all metrics will be produced. See README for a
       # list of suitable terms that can be used here and what metrics they

--- a/libcorsaro/libcorsaro_tagging.c
+++ b/libcorsaro/libcorsaro_tagging.c
@@ -1093,8 +1093,9 @@ static void load_netacq_region_labels(corsaro_logger_t *logger,
     for (i = 0; i < count; i++) {
         index = regions[i]->code;
 
-        /* TODO update libipmeta to add FQIDs to region entities */
-        snprintf(build, 64, "TODO.%u", index);
+        /* TODO update libipmeta to add continent to region entities */
+        snprintf(build, 64, "%s.%s", regions[i]->country_iso,
+                regions[i]->region_iso);
         //snprintf(build, 64, "%s", regions[i]->fqid);
         JLI(pval, ipmeta_state->region_labels, index);
         if (*pval) {

--- a/libcorsaro/plugins/report/processing_thread.c
+++ b/libcorsaro/plugins/report/processing_thread.c
@@ -543,8 +543,7 @@ static inline bool is_allowed_port(uint8_t *portarray, uint16_t portnum) {
 }
 
 #define PROCESS_SINGLE_TAG(class, val, maxval, skipcheck) \
-    if (skipcheck || allowedmetricclasses == 0 || \
-            ((1UL << class) & allowedmetricclasses)) { \
+    if (skipcheck || IS_METRIC_ALLOWED(allowedmetricclasses, class)) { \
         if ((ret = process_single_tag(class, val, maxval, track, logger, \
                 iplen)) < 0) { \
             return -1; \

--- a/libcorsaro/plugins/report/report_internal.h
+++ b/libcorsaro/plugins/report/report_internal.h
@@ -284,6 +284,15 @@ typedef struct allowed_ports {
     uint8_t udp_dests[8192];
 } allowed_ports_t;
 
+/** Level of detail for reporting geo-tagged series
+ *  LITE = just continents and countries
+ *  FULL = continents, countries, regions and counties
+ */
+typedef enum {
+    REPORT_GEOMODE_FULL,
+    REPORT_GEOMODE_LITE
+} corsaro_report_geomode_t;
+
 /** Structure describing configuration specific to the report plugin */
 typedef struct corsaro_report_config {
 
@@ -299,6 +308,9 @@ typedef struct corsaro_report_config {
 
     /** Output format */
     corsaro_output_format_t outformat;
+
+    /** Level of detail for reporting geo-tagged series */
+    corsaro_report_geomode_t geomode;
 
     /** Array of operational IP tracker threads -- included in here because
      *  the merge thread needs to be able to access the thread structures and

--- a/libcorsaro/plugins/report/report_internal.h
+++ b/libcorsaro/plugins/report/report_internal.h
@@ -76,6 +76,9 @@
       ((((uint64_t) class) << 32) + ((uint64_t)val))
 
 
+#define IS_METRIC_ALLOWED(allowedmetrics, metric) \
+      (allowedmetrics == 0 || (allowedmetrics & (1UL << metric)))
+
 /** An upper bound on the number of possible ports */
 #define METRIC_PORT_MAX (65536)
 /** An upper bound on the number of ICMP message types and codes */


### PR DESCRIPTION
For some levels of filtering, we don't really need to continuously track statistics for every single region or county.

This option allows for the region / county / polygon levels of geo-tagging to be ignored by the report plugin if so desired.

Also includes a fix for a bad series labeling bug that I found while testing this new feature -- the bug occurs when corsarotrace is unable to find a suitable IPmeta label for a metric ID for whatever reason. Now such metrics are quietly ignored.