### PR TITLE
report: try to reduce processing workload for unique ASN counts

### DIFF
--- a/libcorsaro/plugins/report/iptracker_thread.c
+++ b/libcorsaro/plugins/report/iptracker_thread.c
@@ -174,7 +174,7 @@ static void update_knownip_metric(corsaro_report_iptracker_t *track,
         m->bytes += tagptr->bytes;
 
         J1S(ret, m->srcips, (Word_t)ipaddr);
-        if (asn != 0) {
+        if (asn != 0 && ret == 1) {
             J1S(ret, m->srcasns, (Word_t)asn);
         }
     } else {


### PR DESCRIPTION
Only try to add the ASN to the ASN map **if** this source IP address is new -- if we already have the address in the IP map,
then we should also already have the corresponding ASN in the ASN map...