### PR TITLE
report: add config options to count aggregated or sampled IPs 

### DIFF
--- a/docs/corsarotrace-README.md
+++ b/docs/corsarotrace-README.md
@@ -387,6 +387,33 @@ The report plugin supports the following configuration options:
                           a particular port metric, then results are produced
                           for all 65536 possible port numbers for that metric.
 
+    src_ip_counting       These options can be used to replace the unique IP
+    dest_ip_counting      address counts with an approximation that is more
+                          efficient to calculate and still reasonably
+                          representative of the overall range of IPs being
+                          observed.
+
+                          These options are expressed as a YAML map with
+                          two sub-parameters: "method" and "subnetmask".
+
+                          The method can be one of the following values:
+                            * prefixagg -- aggregates addresses into prefixes
+                                           and counts the unique prefixes
+                            * sample -- selectively counts only specific
+                                        addresses within a given prefix. The
+                                        sampled address rotates every interval
+                                        within the prefix, so the whole prefix
+                                        is eventually covered over a time
+                                        period.
+                            * none -- counts all unique addresses.
+                          Default method is "none".
+
+                          The "subnetmask" option defines the size of the
+                          prefix to use when aggregating. For example, if set
+                          to 28, the "prefixagg" method will count unique
+                          /28s and the "sample" method will sample one address
+                          per /28 per interval. This option has no effect if
+                          the "none" method is used.
 
 corsarotrace Tag Providers
 ==========================

--- a/exampleconfigs/reportconfig.yaml
+++ b/exampleconfigs/reportconfig.yaml
@@ -130,3 +130,16 @@ plugins:
          - netacq
          - pfx2asn
          - maxmind
+
+      # When counting destination IP addresses, only count unique /28s to
+      # reduce the workload for the plugin.
+      dest_ip_counting:
+        method: "prefixagg"
+        subnetmask: 28
+
+      # You can also modify the counting behaviour for source IP addresses.
+      # This config uses the sampling method to only increment the counter
+      # for one of the addresses in each observed /30 prefix.
+      # src_ip_counting:
+      #   method: "sample"
+      #   subnetmask: 30

--- a/libcorsaro/plugins/report/corsaro_report.c
+++ b/libcorsaro/plugins/report/corsaro_report.c
@@ -639,6 +639,8 @@ int corsaro_report_finalise_config(corsaro_plugin_t *p,
         pthread_mutex_init(&(conf->iptrackers[i].mutex), NULL);
         conf->iptrackers[i].lastresultts = 0;
 
+        conf->iptrackers[i].inbuf = NULL;
+        conf->iptrackers[i].inbuflen = 0;
         conf->iptrackers[i].prev_maps = NULL;
         conf->iptrackers[i].curr_maps = NULL;
         conf->iptrackers[i].next_maps = NULL;
@@ -735,6 +737,9 @@ void corsaro_report_destroy_self(corsaro_plugin_t *p) {
                 for (j = 0; j < conf->basic.procthreads; j++) {
                     zmq_close(conf->tracker_queues[
                             i * conf->basic.procthreads + j]);
+                }
+                if (conf->iptrackers[i].inbuf) {
+                    free(conf->iptrackers[i].inbuf);
                 }
                 free(conf->iptrackers[i].sourcetrack);
                 libtrace_list_deinit(conf->iptrackers[i].outstanding);

--- a/libcorsaro/plugins/report/iptracker_thread.c
+++ b/libcorsaro/plugins/report/iptracker_thread.c
@@ -490,13 +490,13 @@ static void process_interval_reset_message(corsaro_report_iptracker_t *track,
         track->srcip_sample_index ++;
 
         if (track->srcip_sample_index >=
-                    pow(2, track->conf->src_ipcount_conf.pfxbits)) {
+                    pow(2, (32 - track->conf->src_ipcount_conf.pfxbits))) {
             track->srcip_sample_index = 0;
         }
 
         track->dstip_sample_index ++;
         if (track->dstip_sample_index >=
-                    pow(2, track->conf->dst_ipcount_conf.pfxbits)) {
+                    pow(2, (32 - track->conf->dst_ipcount_conf.pfxbits))) {
             track->dstip_sample_index = 0;
         }
     } else {

--- a/libcorsaro/plugins/report/iptracker_thread.c
+++ b/libcorsaro/plugins/report/iptracker_thread.c
@@ -216,7 +216,7 @@ static void update_knownip_metric(corsaro_report_iptracker_t *track,
     } else {
         if (should_count_address(ipaddr, &tocount,
                 &(track->conf->dst_ipcount_conf), track->dstip_sample_index)) {
-            J1S(ret, m->destips, (Word_t)ipaddr);
+            J1S(ret, m->destips, (Word_t)tocount);
         }
     }
 }

--- a/libcorsaro/plugins/report/iptracker_thread.c
+++ b/libcorsaro/plugins/report/iptracker_thread.c
@@ -487,19 +487,17 @@ static void process_interval_reset_message(corsaro_report_iptracker_t *track,
     if (msg->msgtype == CORSARO_IP_MESSAGE_INTERVAL) {
         track->prev_maps = track->curr_maps;
         track->lastresultts = complete;
-        if (msg->sender == 0) {
-            track->srcip_sample_index ++;
+        track->srcip_sample_index ++;
 
-            if (track->srcip_sample_index >=
-                        pow(2, track->conf->src_ipcount_conf.pfxbits)) {
-                track->srcip_sample_index = 0;
-            }
+        if (track->srcip_sample_index >=
+                    pow(2, track->conf->src_ipcount_conf.pfxbits)) {
+            track->srcip_sample_index = 0;
+        }
 
-            track->dstip_sample_index ++;
-            if (track->dstip_sample_index >=
-                        pow(2, track->conf->dst_ipcount_conf.pfxbits)) {
-                track->dstip_sample_index = 0;
-            }
+        track->dstip_sample_index ++;
+        if (track->dstip_sample_index >=
+                    pow(2, track->conf->dst_ipcount_conf.pfxbits)) {
+            track->dstip_sample_index = 0;
         }
     } else {
         free_map_set(track->curr_maps);

--- a/libcorsaro/plugins/report/iptracker_thread.c
+++ b/libcorsaro/plugins/report/iptracker_thread.c
@@ -487,17 +487,19 @@ static void process_interval_reset_message(corsaro_report_iptracker_t *track,
     if (msg->msgtype == CORSARO_IP_MESSAGE_INTERVAL) {
         track->prev_maps = track->curr_maps;
         track->lastresultts = complete;
-        track->srcip_sample_index ++;
+        if (msg->sender == 0) {
+            track->srcip_sample_index ++;
 
-        if (track->srcip_sample_index >=
-                    pow(2, track->conf->src_ipcount_conf.pfxbits)) {
-            track->srcip_sample_index = 0;
-        }
+            if (track->srcip_sample_index >=
+                        pow(2, track->conf->src_ipcount_conf.pfxbits)) {
+                track->srcip_sample_index = 0;
+            }
 
-        track->dstip_sample_index ++;
-        if (track->dstip_sample_index >=
-                    pow(2, track->conf->dst_ipcount_conf.pfxbits)) {
-            track->dstip_sample_index = 0;
+            track->dstip_sample_index ++;
+            if (track->dstip_sample_index >=
+                        pow(2, track->conf->dst_ipcount_conf.pfxbits)) {
+                track->dstip_sample_index = 0;
+            }
         }
     } else {
         free_map_set(track->curr_maps);

--- a/libcorsaro/plugins/report/iptracker_thread.c
+++ b/libcorsaro/plugins/report/iptracker_thread.c
@@ -91,7 +91,7 @@ static inline bool should_count_address(uint32_t ipaddr, uint32_t *tocount,
     if (ipconf->method == REPORT_IPCOUNT_METHOD_SAMPLE) {
         mask = (0xFFFFFFFF << (32 - ipconf->pfxbits));
 
-        if (swapped - mask == sample_index) {
+        if (swapped - (swapped & mask) == sample_index) {
             *tocount = swapped;
             return true;
         }

--- a/libcorsaro/plugins/report/report_internal.h
+++ b/libcorsaro/plugins/report/report_internal.h
@@ -228,6 +228,9 @@ typedef struct corsaro_report_iptracker {
     /** The queue for reading incoming messages from the processing threads */
     void *incoming;
 
+    uint8_t *inbuf;
+    uint32_t inbuflen;
+
     /** The timestamp of the interval that our most recent complete tally
      *  belongs to.
      */


### PR DESCRIPTION
The main purpose of these options is to try and offer more efficient methods of counting that trade-off CPU usage against the precision of the numbers reported for the unique IP counts.

The numbers instead become an approximation, but should still follow any major changes or spikes that we would otherwise see with the full unique IP counts.

Two methods have been added:
 * prefix aggregation, which simply counts unique /N prefixes where N is configurable -- performance gains are modest in terms of CPU, good in terms of memory, relative precision loss is low
 * sampling, which only increments the counter if the observed address is a particular one for a given /N prefix. The sampled address changes each interval to try and avoid side-effects due to particular addresses being more or less popular than others within a prefix. Performance gains are higher for both CPU and memory, but you also lose a fair bit more precision.

Prefix aggregation is the conservative option, sampling is a more drastic approach.

Also includes a few other minor performance tweaks to skip over unnecessary operations, e.g. avoid doing work that only applies to metrics that are currently disabled, etc.