### PR TITLE
corsarotagger: do not free outdated IPmeta info in tagging threads

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,12 +22,12 @@
 # along with corsaro.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-AC_INIT([corsaro], [3.2.12], [corsaro-info@caida.org])
+AC_INIT([corsaro], [3.2.13], [corsaro-info@caida.org])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 
 CORSARO_MAJOR_VERSION=3
 CORSARO_MID_VERSION=2
-CORSARO_MINOR_VERSION=12
+CORSARO_MINOR_VERSION=13
 
 AC_DEFINE_UNQUOTED([CORSARO_MAJOR_VERSION],$CORSARO_MAJOR_VERSION,
 	[corsaro major version])

--- a/corsarotagger/corsarotagger.h
+++ b/corsarotagger/corsarotagger.h
@@ -140,6 +140,7 @@ typedef struct corsaro_tagger_glob {
     netacq_opts_t netacqtagopts;
 
     corsaro_ipmeta_state_t *ipmeta_state;
+    corsaro_ipmeta_state_t *prev_ipmeta_state;
     uint32_t ipmeta_version;
 
     /** A libtrace hasher function that can be used to distribute received

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+corsaro (3.2.13) unstable; urgency=medium
+
+  * Prevent libipmeta updates from interfering with corsarotagger
+    tagging threads.
+
+ -- Shane Alcock <software@caida.org>  Mon, 14 Dec 2020 18:09:21 -0800
+
 corsaro (3.2.12) unstable; urgency=medium
 
   * Fix time series bug where IP counters were too high for Netacq

--- a/libcorsaro/libcorsaro_tagging.c
+++ b/libcorsaro/libcorsaro_tagging.c
@@ -369,7 +369,6 @@ void corsaro_replace_tagger_ipmeta(corsaro_packet_tagger_t *tagger,
     if (tagger->ipmeta_state->refcount == 0) {
         tagger->ipmeta_state->ending = 1;
         pthread_mutex_unlock(&(tagger->ipmeta_state->mutex));
-        corsaro_free_ipmeta_state(tagger->ipmeta_state);
     } else {
         pthread_mutex_unlock(&(tagger->ipmeta_state->mutex));
     }


### PR DESCRIPTION
This change aims to resolve packet loss issues seen in production whenever an IPmeta reload is triggered on a tagger.