### PR TITLE
Report change default partitioning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ AM_INIT_AUTOMAKE([foreign subdir-objects])
 # update before each release according to the rules defined at
 # https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 CORSARO_LIBTOOL_CURRENT=4
-CORSARO_LIBTOOL_REVISION=5
+CORSARO_LIBTOOL_REVISION=2
 CORSARO_LIBTOOL_AGE=0
 
 AC_DEFINE_UNQUOTED([CORSARO_LIBTOOL_CURRENT],$CORSARO_LIBTOOL_CURRENT,

--- a/configure.ac
+++ b/configure.ac
@@ -22,13 +22,13 @@
 # along with corsaro.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-AC_INIT([corsaro], [3.4.0], [corsaro-info@caida.org])
+AC_INIT([corsaro], [3.4.1], [corsaro-info@caida.org])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 
 # update before each release according to the rules defined at
 # https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 CORSARO_LIBTOOL_CURRENT=4
-CORSARO_LIBTOOL_REVISION=1
+CORSARO_LIBTOOL_REVISION=5
 CORSARO_LIBTOOL_AGE=0
 
 AC_DEFINE_UNQUOTED([CORSARO_LIBTOOL_CURRENT],$CORSARO_LIBTOOL_CURRENT,

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+corsaro (3.4.1) unstable; urgency=medium
+
+  * Report: time series which are written to kafka are now
+    partitioned based on the series key (by default), rather than
+    by timestamp.
+
+ -- Shane Alcock <software@caida.org>  Tue, 15 Jun 2021 10:24:41 +1200
+
 corsaro (3.4.0) unstable; urgency=medium
 
   * Fixed various bugs in the DOS attack vector detection code so it

--- a/debian/control
+++ b/debian/control
@@ -5,8 +5,8 @@ Maintainer: CAIDA Software Maintainer <software@caida.org>
 Build-Depends: debhelper (>= 10), autotools-dev, libc6-dev,
  libpcap-dev, libyaml-dev, libjudy-dev, uthash-dev, libzmq3-dev, libavro-dev,
  libipmeta2-dev (>=3.0.0), libavro-dev, libtrace4-dev (>=4.0.12),
- libtimeseries0-dev, libwandio1-dev (>=4.2.0), librdkafka-dev (>=0.11.3),
- libndagserver-dev, libgoogle-perftools-dev
+ libtimeseries0-dev (>=1.0.3), libwandio1-dev (>=4.2.0),
+ librdkafka-dev (>=0.11.3), libndagserver-dev, libgoogle-perftools-dev
 Standards-Version: 4.1.2
 Homepage: https://github.com/CAIDA/corsaro
 

--- a/libcorsaro/libcorsaro_libtimeseries.c
+++ b/libcorsaro/libcorsaro_libtimeseries.c
@@ -366,7 +366,7 @@ int configure_libts_kafka_backend(corsaro_logger_t *logger,
             back->compresscodec = strdup("snappy");
         }
         if (back->format == NULL) {
-            back->format = strdup("tsk");
+            back->format = strdup("tskkey");
         }
         if (back->topicprefix == NULL) {
             back->topicprefix = strdup("");


### PR DESCRIPTION
Also bump version to 3.4.1

 * By default, time series output will use the new 'tskkey' partitioning scheme added in libtimeseries 1.0.3
 * Update debian control to require libtimeseries-dev >= 1.0.3