### PR TITLE
rsdos2ascii: disable dumping initial packet using libpacketdump

### DIFF
--- a/docker/rsdos2-ascii/Dockerfile
+++ b/docker/rsdos2-ascii/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get -y update && apt-get -y install \
         libpcap-dev \
         librdkafka-dev \
         libtool \
+        libtrace4-dev \
         libwandio1-dev \
         libyaml-dev \
         libzmq3-dev \
@@ -80,6 +81,7 @@ RUN apt-get -y update && apt-get -y install \
         python3 \
         python-swiftclient \
         screen \
+        sed \
         strace \
         tcpdump \
         unzip \
@@ -88,10 +90,11 @@ RUN apt-get -y update && apt-get -y install \
         vim \
         wandio1-tools
 
-RUN git clone https://github.com/LibtraceTeam/libtrace && cd libtrace && git checkout develop
-RUN cd libtrace && ./bootstrap.sh && ./configure && make && make install && ldconfig
+#RUN git clone https://github.com/LibtraceTeam/libtrace && cd libtrace && git checkout develop
+#RUN cd libtrace && ./bootstrap.sh && ./configure && make && make install && ldconfig
 
 RUN git clone https://github.com/CAIDA/corsaro3 && cd corsaro3 && git checkout v2 && git submodule init && git submodule update
+RUN sed -i -e '1381,1383d' corsaro3/libcorsaro/plugins/corsaro_dos.c
 RUN cd corsaro3 && autoreconf -vfi && ./configure --with-slash-eight=0 --with-dos --enable-debug && make && make install && ldconfig
 
 RUN rm -rf corsaro3/


### PR DESCRIPTION
This should prevent any further crashes due to libpacketdump
failing to safely decode a bogus initial packet -- we don't
need to decode the packet to generate our CSVs, so just
disable the dumping and remove the "warning" about libpacketdump
not being available.